### PR TITLE
Fixed Typo forControlName should be fomrControlName in ReactiveStatusListenableBuilder

### DIFF
--- a/lib/src/widgets/reactive_status_listenable_builder.dart
+++ b/lib/src/widgets/reactive_status_listenable_builder.dart
@@ -28,7 +28,7 @@ class ReactiveStatusListenableBuilder extends StatelessWidget {
   ///
   /// The [builder] function must not be null.
   ///
-  /// Must provide a [forControlName] or a [formControl] but not both
+  /// Must provide a [formControlName] or a [formControl] but not both
   /// at the same time.
   ///
   const ReactiveStatusListenableBuilder({


### PR DESCRIPTION
Update reactive_status_listenable_builder.dart

Variable name `formControlName` is different in the Doc comment